### PR TITLE
Add elapsed time

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -704,7 +704,7 @@ export default class ApiRequest extends LitElement {
     const responseFormat = this.responseHeaders.includes('json') ? 'json' : (this.responseHeaders.includes('html') || this.responseHeaders.includes('xml')) ? 'html' : '';
     return html`
       <div class="row" style="font-size:var(--font-size-small); margin:5px 0">
-        <div class="response-message ${this.responseStatus}">Response Status: ${this.responseMessage}</div>
+        <div class="response-message ${this.responseStatus}">Response Status: ${this.responseMessage} in ${this.elapsedMs}ms</div>
         <div style="flex:1"></div>
         <button class="m-btn" part="btn btn-outline" @click="${this.clearResponseData}">CLEAR RESPONSE</button>
       </div>
@@ -1050,7 +1050,9 @@ export default class ApiRequest extends LitElement {
       let respJson;
       let respText;
       tryBtnEl.disabled = true;
+      const fetchStart = new Date();
       fetchResponse = await fetch(fetchRequestObject);
+      this.elapsedMs = new Date() - fetchStart;
       tryBtnEl.disabled = false;
       this.responseStatus = fetchResponse.ok ? 'success' : 'error';
       this.responseMessage = fetchResponse.statusText ? `${fetchResponse.statusText}:${fetchResponse.status}` : fetchResponse.status;

--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -1216,7 +1216,7 @@ export default class ApiRequest extends LitElement {
     this.responseText = '';
     this.responseStatus = '';
     this.responseMessage = '';
-    this.responseElapsedMs = '';
+    this.responseElapsedMs = 0;
     this.responseIsBlob = false;
     this.responseBlobType = '';
     this.respContentDisposition = '';

--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -24,6 +24,7 @@ export default class ApiRequest extends LitElement {
     this.responseHeaders = '';
     this.responseText = '';
     this.responseUrl = '';
+    this.responseElapsedMs = 0;
     this.curlSyntax = '';
     this.activeResponseTab = 'response'; // allowed values: response, headers, curl
     this.selectedRequestBodyType = '';
@@ -47,6 +48,7 @@ export default class ApiRequest extends LitElement {
       responseHeaders: { type: String, attribute: false },
       responseStatus: { type: String, attribute: false },
       responseUrl: { type: String, attribute: false },
+      responseElapsedMs: { type: Number, attribute: false },
       fillRequestWithDefault: { type: String, attribute: 'fill-defaults' },
       allowTry: { type: String, attribute: 'enable-console' },
       renderStyle: { type: String, attribute: 'render-style' },
@@ -704,8 +706,10 @@ export default class ApiRequest extends LitElement {
     const responseFormat = this.responseHeaders.includes('json') ? 'json' : (this.responseHeaders.includes('html') || this.responseHeaders.includes('xml')) ? 'html' : '';
     return html`
       <div class="row" style="font-size:var(--font-size-small); margin:5px 0">
-        <div class="response-message ${this.responseStatus}">Response Status: ${this.responseMessage} in ${this.elapsedMs}ms</div>
-        <div style="flex:1"></div>
+      <div class="response-message ${this.responseStatus}">Response Status: ${this.responseMessage}
+        ${this.responseElapsedMs ? html`<span><br>Execution Time: ${this.responseElapsedMs}ms</span>` : ''}
+      </div>
+      <div style="flex:1"></div>
         <button class="m-btn" part="btn btn-outline" @click="${this.clearResponseData}">CLEAR RESPONSE</button>
       </div>
       <div class="tab-panel col" style="border-width:0 0 1px 0;">
@@ -1052,7 +1056,7 @@ export default class ApiRequest extends LitElement {
       tryBtnEl.disabled = true;
       const fetchStart = new Date();
       fetchResponse = await fetch(fetchRequestObject);
-      this.elapsedMs = new Date() - fetchStart;
+      this.responseElapsedMs = new Date() - fetchStart;
       tryBtnEl.disabled = false;
       this.responseStatus = fetchResponse.ok ? 'success' : 'error';
       this.responseMessage = fetchResponse.statusText ? `${fetchResponse.statusText}:${fetchResponse.status}` : fetchResponse.status;
@@ -1212,6 +1216,7 @@ export default class ApiRequest extends LitElement {
     this.responseText = '';
     this.responseStatus = '';
     this.responseMessage = '';
+    this.responseElapsedMs = '';
     this.responseIsBlob = false;
     this.responseBlobType = '';
     this.respContentDisposition = '';


### PR DESCRIPTION
Display how long the API call took next to the response. This is useful for my team here as we're starting to look at our API performance, so maybe some other users could use it too

Some screenshots:
- a 200 
<img width="288" alt="image" src="https://user-images.githubusercontent.com/2975941/153495554-e3aec8de-0a3a-4617-9780-348970702a0a.png">
- a 500
<img width="303" alt="image" src="https://user-images.githubusercontent.com/2975941/153495589-bba693f7-1ed4-4cfb-829a-5a42c8742f06.png">

It's not perfect (upload time is included), but getting detailed metrics on Fetch API is more work than I can afford right now
