### PR TITLE
Enable overriding the request body with a custom slot.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This package follows standard semvar, `<major>.<minor>.<build>`. No breaking cha
 * Fix issues with allOf/oneOf with partially completed data.
 * Sanitize paths coming from the spec that contain invalid characters.
 * Improve display of array types and number/string formats in parameters and models
+* Fix fetch request options to not require unnecessary extra level in setting properties.
 
 ## 0.8 ##
 * Removing the `RESET` button as it is confusing for users to see. It only repopulated the defaults, and to do that, you can easily switch tabs and come back.

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -76,7 +76,7 @@ onSpecLoaded(data) {
 
 ```js
 requestInterceptor(event) {
-  event.detail.request.options.headers.append('Authorization', `Bearer ${userToken}`);
+  event.detail.request.headers.append('Authorization', `Bearer ${userToken}`);
 }
 ```
 
@@ -119,8 +119,10 @@ responseInterceptor(event) {
   <div>Methods</div>
   <hr>
 </div>
+```
 
 #### Custom Navigation section
+```html
 <!-- Add custom nav sections to link to the custom section -->
 <div slot="nav-section">Section 1</div>
 <div slot="nav-section">Section 2</div>
@@ -129,14 +131,15 @@ responseInterceptor(event) {
 <div slot="custom-section">
   <h1>A custom section rendered when selected.</h1>
 </div>
+```
 
 #### Tag and operations slot configuration
-
+```html
 <!-- Hide a tag from navigation -->
-<div div="nav-tag--${tagName}"></div>
+<div slot="nav-tag--${tagName}"></div>
 
-<div div="tag--${tagName}"></div>
-<div div="tag--${tagName}--subsection--${subsectionName}"></div>
+<div slot="tag--${tagName}"></div>
+<div slot="tag--${tagName}--subsection--${subsectionName}"></div>
 
 <!--
   Example: GET /v1/resources/{resourceUri}/users becomes => get-/v1/resources/-resourceUri-/users
@@ -148,6 +151,26 @@ responseInterceptor(event) {
 </div>
 
 ```
+
+#### Overwrite request body area
+```html
+<div slot="${this.elementId}--request-body">
+  <!-- Example filling this with a custom text area -->
+  <textarea id="text-body-area-override" class="textarea request-body-param-user-input" part="textarea textarea-param" spellcheck="false" style="width:100%; resize:vertical;">
+    { "Example Data": "" }
+  </textarea>
+</div>
+```
+
+After the user interacts with this component (or your custom implementation), you'll want path this back as input to the actual request:
+
+```js
+requestInterceptor(event) {
+  const textareaObject = document.getElementById("text-body-area-override");
+  event.detail.request.body = textareaObject.value;
+}
+```
+
 
 ### SDK code samples
 OpenAPI Explorer supports inline code samples using the `x-code-samples` OpenAPI vendor extension. Just add your code sample into the array and it will dynamically appear as an example in the doc.

--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -39,6 +39,7 @@ export default class ApiRequest extends LitElement {
       servers: { type: Array },
       method: { type: String },
       path: { type: String },
+      elementId: { type: String, attribute: 'element-id' },
       parameters: { type: Array },
       request_body: { type: Object },
       api_keys: { type: Array },
@@ -293,7 +294,7 @@ export default class ApiRequest extends LitElement {
     let reqBodyFileInputHtml = '';
     let reqBodyFormHtml = '';
     let reqBodySchemaHtml = '';
-    let reqBodyExampleHtml = '';
+    let reqBodyDefaultHtml = '';
 
     const requestBodyTypes = [];
     const content = this.request_body.content;
@@ -341,8 +342,8 @@ export default class ApiRequest extends LitElement {
           if (!this.selectedRequestBodyExample) {
             this.selectedRequestBodyExample = (reqBodyExamples.length > 0 ? reqBodyExamples[0].exampleId : '');
           }
-          reqBodyExampleHtml = html`
-            ${reqBodyExampleHtml}
+          reqBodyDefaultHtml = html`
+            ${reqBodyDefaultHtml}
             <div class = 'example-panel border-top pad-top-8'>
               ${reqBodyExamples.length === 1
                 ? ''
@@ -360,19 +361,20 @@ export default class ApiRequest extends LitElement {
                 <div class="example ${v.exampleId === this.selectedRequestBodyExample ? 'example-selected' : ''}" data-default = '${v.exampleId}'>
                   ${v.exampleSummary && v.exampleSummary.length > 80 ? html`<div style="padding: 4px 0"> ${v.exampleSummary} </div>` : ''}
                   ${v.exampleDescription ? html`<div class="m-markdown-small" style="padding: 4px 0"> ${unsafeHTML(marked(v.exampleDescription || ''))} </div>` : ''}
-                  <!-- this textarea is for user to edit the example -->
-                  <textarea 
-                    class = "textarea request-body-param-user-input"
-                    part = "textarea textarea-param"
-                    spellcheck = "false"
-                    data-ptype = "${reqBody.mimeType}" 
-                    data-default = "${v.exampleFormat === 'text' ? v.exampleValue : JSON.stringify(v.exampleValue, null, 8)}"
-                    data-default-format = "${v.exampleFormat}"
-                    style="width:100%; resize:vertical;"
-                  >${this.fillRequestWithDefault === 'true'
-                      ? (v.exampleFormat === 'text' ? v.exampleValue : JSON.stringify(v.exampleValue, null, 8))
-                      : ''
-                    }</textarea>
+                    <!-- this textarea is for user to edit the example -->
+                  <slot name="${this.elementId}--request-body">
+                    <textarea 
+                      class = "textarea request-body-param-user-input"
+                      part = "textarea textarea-param"
+                      spellcheck = "false"
+                      data-ptype = "${reqBody.mimeType}" 
+                      data-default = "${v.exampleFormat === 'text' ? v.exampleValue : JSON.stringify(v.exampleValue, null, 8)}"
+                      data-default-format = "${v.exampleFormat}"
+                      style="width:100%; resize:vertical;">
+                      ${this.fillRequestWithDefault === 'true' ? (v.exampleFormat === 'text' ? v.exampleValue : JSON.stringify(v.exampleValue, null, 8)) : ''}
+                    </textarea>
+                  </slot>
+
                   <!-- This textarea(hidden) is to store the original example value, this will remain unchanged when users switches from one example to another, its is used to populate the editable textarea -->
                   <textarea 
                     class = "textarea is-hidden request-body-param ${reqBody.mimeType.substring(reqBody.mimeType.indexOf('/') + 1)}" 
@@ -461,7 +463,7 @@ export default class ApiRequest extends LitElement {
                 <button class="tab-btn ${this.activeSchemaTab === 'body' ? 'active' : ''}" data-tab="body">BODY</button>
               </div>
               ${html`<div class="tab-content col" style="display: ${this.activeSchemaTab === 'model' ? 'block' : 'none'}"> ${reqBodySchemaHtml}</div>`}
-              ${html`<div class="tab-content col" style="display: ${this.activeSchemaTab === 'model' ? 'none' : 'block'}"> ${reqBodyExampleHtml}</div>`}
+              ${html`<div class="tab-content col" style="display: ${this.activeSchemaTab === 'model' ? 'none' : 'block'}"> ${reqBodyDefaultHtml}</div>`}
             </div>`
           : html`  
             ${reqBodyFileInputHtml}
@@ -1018,7 +1020,8 @@ export default class ApiRequest extends LitElement {
       fetchOptions.credentials = this.fetchCredentials;
     }
 
-    const fetchRequest = { url: fetchUrl, options: fetchOptions };
+    // Options is legacy usage, documentation has been updated to reference properties of the fetch option directly, but older usages may still be using options
+    const fetchRequest = { elementId: this.elementId, url: fetchUrl, options: fetchOptions, ...fetchOptions };
     const event = {
       bubbles: true,
       composed: true,
@@ -1028,7 +1031,13 @@ export default class ApiRequest extends LitElement {
     };
     this.dispatchEvent(new CustomEvent('before-try', event));
     this.dispatchEvent(new CustomEvent('request', event));
-    const fetchRequestObject = new Request(fetchUrl, fetchOptions);
+    const newFetchOptions = {
+      method: fetchRequest.method || fetchRequest.options.method,
+      headers: fetchRequest.headers || fetchOptions.options.headers,
+      credentials: fetchRequest.credentials || fetchOptions.options.credentials,
+      body: fetchRequest.body || fetchOptions.options.body
+    };
+    const fetchRequestObject = new Request(fetchRequest.url, newFetchOptions);
 
     let fetchResponse;
     try {

--- a/src/templates/endpoint-template.js
+++ b/src/templates/endpoint-template.js
@@ -99,10 +99,11 @@ function endpointBodyTemplate(path) {
           style = "width:100%;"
           method = "${path.method}", 
           path = "${path.path}" 
+          element-id = "${path.elementId}"
           .parameters = "${path.parameters}"
           .request_body = "${path.requestBody}"
           .api_keys = "${nonEmptyApiKeys}"
-          .servers = "${path.servers}" 
+          .servers = "${path.servers}"
           server-url = "${path.servers && path.servers.length > 0 ? path.servers[0].url : this.selectedServer.computedUrl}" 
           active-schema-tab = "${this.defaultSchemaTab}"
           fill-defaults = "${this.fillRequestWithDefault}"

--- a/src/templates/expanded-endpoint-template.js
+++ b/src/templates/expanded-endpoint-template.js
@@ -42,6 +42,7 @@ export function expandedEndpointBodyTemplate(path, tagName = '') {
       <api-request class="request-panel"
         method = "${path.method}"
         path = "${path.path}"
+        element-id = "${path.elementId}"
         .parameters = "${path.parameters}"
         .request_body = "${path.requestBody}"
         .api_keys = "${nonEmptyApiKeys}"


### PR DESCRIPTION
Hey @nikitapatel029. Just wanted to let you know that we liked your idea over in the fork of the explorer that we decided to pull in a partial solution for this.

This openapi-explorer now supports via this PR the ability to override the request body area and enter your own replacement for it.

You can take a look at the functionality from this PR or pull in the version and let us know if this would solve your issue or if there would need to be other improvements as well. While we can't support everything, we thought this could be an interesting direction to go.