### PR TITLE
Add support for external docs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ This package follows standard semvar, `<major>.<minor>.<build>`. No breaking cha
 ## 0.11 ##
 * Fix `allOf` for response schema. #119
 * Fixing handling of openapi paths that include url characters
+* Add support for showing external docs
 
 ## 0.10 ##
 * Internationalization support with languages `en` and `fr`
+<<<<<<< HEAD
 * Add a `slot` `nav-header` to the top of the navbar.
 * Add ruby to available languages.
 * Handle missing schema's for responses

--- a/src/openapi-explorer.js
+++ b/src/openapi-explorer.js
@@ -154,6 +154,10 @@ export default class OpenApiExplorer extends LitElement {
         overflow:hidden;
       }
 
+      a {
+        text-decoration: none;
+      }
+
       .main-content { 
         margin:0;
         padding: 0; 

--- a/src/styles/font-styles.js
+++ b/src/styles/font-styles.js
@@ -58,6 +58,7 @@ export default css`
 
   h1,h2,h3,h4,h5,h5{
     margin-block-end: 0.2em;
+    margin-block-start: 0.5em;
   }
   h3 {
     margin-top: 0;
@@ -83,6 +84,7 @@ export default css`
   }
 
   .m-markdown p,
+  .m-markdown a,
   .m-markdown span,
   .m-markdown li {
     font-size: var(--font-size-regular);
@@ -90,6 +92,7 @@ export default css`
   }
   
   .m-markdown-small p,
+  .m-markdown-small a,
   .m-markdown-small span,
   .m-markdown-small li {
     font-size: var(--font-size-small);
@@ -109,6 +112,8 @@ export default css`
 
   .m-markdown p, .m-markdown-small p {
     margin-block-end: 0;
+    overflow-wrap: anywhere;
+
   }
 
   .toolbar .m-markdown p, .toolbar .m-markdown-small p {
@@ -182,9 +187,8 @@ export default css`
     padding-inline-start: 20px;
   }
 
-  .m-markdown-small a,
-  .m-markdown a {
-    color:var(--blue);
+  .m-markdown a, .m-markdown-small a {
+    color:var(--blue); 
   }
 
   .m-markdown-small img,

--- a/src/templates/expanded-endpoint-template.js
+++ b/src/templates/expanded-endpoint-template.js
@@ -11,7 +11,7 @@ import '../components/api-response';
 export function expandedEndpointBodyTemplate(path, tagName = '') {
   const acceptContentTypes = new Set();
   for (const respStatus in path.responses) {
-    for (const acceptContentType in path.responses[respStatus] && path.responses[respStatus].content) {
+    for (const acceptContentType in path.responses[respStatus]?.content) {
       acceptContentTypes.add(acceptContentType.trim());
     }
   }
@@ -26,15 +26,23 @@ export function expandedEndpointBodyTemplate(path, tagName = '') {
     <div class='expanded-endpoint-body observe-me ${path.method}' part="section-operation ${path.elementId}" id='${path.elementId}'>
     ${(this.renderStyle === 'focused' && tagName && tagName !== 'General ⦂') ? html`<h3 class="upper" style="font-weight:bold"> ${tagName} </h3>` : ''}
     ${path.deprecated ? html`<div class="bold-text red-text"> DEPRECATED </div>` : ''}
-    ${html`
-      <h2> ${path.shortSummary || `${path.method.toUpperCase()} ${path.path}`}</h2>
-      <div class='mono-font part="section-operation-url" regular-font-size' style='padding: 8px 0; color:var(--fg3)'> 
-        ${path.isWebhook ? html`<span style="color:var(--primary-color)"> WEBHOOK </span>` : ''}
-        <span part="label-operation-method" class='regular-font upper method-fg bold-text ${path.method}'>${path.method}</span> 
-        <span part="label-operation-path">${path.path}</span>
-      </div>`
-    }
-    ${path.description ? html`<div class="m-markdown"> ${unsafeHTML(marked(path.description))}</div>` : ''}
+    <div style="display: flex; justify-content: space-between">
+      <div style="flex-grow: 1">
+        <h2>${path.shortSummary || `${path.method.toUpperCase()} ${path.path}`}</h2>
+        <div class='mono-font part="section-operation-url" regular-font-size' style='padding: 8px 0; color:var(--fg3)'> 
+          ${path.isWebhook ? html`<span style="color:var(--primary-color)"> WEBHOOK </span>` : ''}
+          <span part="label-operation-method" class='regular-font upper method-fg bold-text ${path.method}'>${path.method}</span> 
+          <span part="label-operation-path">${path.path}</span>
+        </div>
+      </div>
+      ${path.externalDocs
+        ? html`<div class="m-markdown" style="margin-top: 2rem; margin-bottom: 0.5rem; max-width: 300px">
+            ${unsafeHTML(marked(path.externalDocs.description || ''))}
+            <a href="${path.externalDocs.url}">Navigate to documentation ↗</a>
+          </div>`
+        : ''}
+    </div>
+    <div class="m-markdown" style="margin-right: 2rem;"> ${unsafeHTML(marked(path.description || ''))}</div>
     <slot name="${path.elementId}"></slot>
     ${pathSecurityTemplate.call(this, path.security)}
     ${codeSampleTabPanel}

--- a/src/templates/focused-endpoint-template.js
+++ b/src/templates/focused-endpoint-template.js
@@ -20,8 +20,8 @@ function defaultContentTemplate() {
     return overviewTemplate.call(this);
   }
   const selectedTagObj = this.resolvedSpec.tags[0];
-  const selectedPathObj = selectedTagObj && selectedTagObj.paths[0];
-  return (selectedTagObj && selectedPathObj)
+  const selectedPathObj = selectedTagObj?.paths[0];
+  return (selectedPathObj)
     ? wrapFocusedTemplate(expandedEndpointBodyTemplate.call(this, selectedPathObj, selectedTagObj.name))
     : wrapFocusedTemplate('');
 }

--- a/src/utils/spec-parser.js
+++ b/src/utils/spec-parser.js
@@ -295,6 +295,7 @@ function groupByTags(openApiSpec) {
             callbacks: pathOrHookObj.callbacks,
             deprecated: pathOrHookObj.deprecated,
             security: pathOrHookObj.security || openApiSpec.security,
+            externalDocs: pathOrHookObj.externalDocs,
             // commonSummary: commonPathProp.summary,
             // commonDescription: commonPathProp.description,
             xCodeSamples: pathOrHookObj['x-codeSamples'] || pathOrHookObj['x-code-samples'] || '',


### PR DESCRIPTION
@lequant40 and @rberger, Over here in the OpenAPI Explorer, we wanted to focus on support for 3.1, which means every property for us. So, I wanted to take a whack at what you mentioned in RapiDoc regarding external docs display. I'd be curious if something like this would make sense to display the `externalDocs` or different display elements would be necessary.

![image](https://user-images.githubusercontent.com/5056218/189482998-1d97ccb2-19f9-4f48-b970-93f308afc6a2.png)
