### PR TITLE
Add support for "pattern properties" in schema display

### DIFF
--- a/src/utils/schema-utils.js
+++ b/src/utils/schema-utils.js
@@ -442,6 +442,9 @@ export function schemaInObjectNotation(rawSchema, options, level = 0, suffix = '
         obj[key] = schemaInObjectNotation(schema.properties[key], options, (level + 1));
       }
     }
+    for (const key in schema.patternProperties) {
+      obj[`<pattern: ${key}>`] = schemaInObjectNotation(schema.patternProperties[key], options, (level + 1));
+    }
     if (schema.additionalProperties) {
       obj['<any-key>'] = schemaInObjectNotation(schema.additionalProperties, options);
     }


### PR DESCRIPTION
JSON Schema (and therefore OpenAPI 3.1) includes support for "pattern properties", which match properties based on a regex. This patch adds these to the schema view in a similar style to "additional properties", e.g. pattern '^abc-\d+$' shows as '<pattern: ^abc-\d+$>'

https://json-schema.org/understanding-json-schema/reference/object.html#pattern-properties