### PR TITLE
Fix "process is not defined" error rendering XML responses

### DIFF
--- a/src/utils/xml/xml.js
+++ b/src/utils/xml/xml.js
@@ -30,15 +30,6 @@ export default function xml(input, rawOptions) {
   const indent = !options.indent ? ''
     : options.indent === true ? DEFAULT_INDENT
       : options.indent;
-  let instant = true;
-
-  function delay(func) {
-    if (!instant) {
-      func();
-    } else {
-      process.nextTick(func);
-    }
-  }
 
   function append(_, out) {
     if (out !== undefined) {
@@ -61,9 +52,6 @@ export default function xml(input, rawOptions) {
     add({ '?xml': { _attr: attr } });
     output = output.replace('/>', '?>');
   }
-
-  // disable delay delayed
-  delay(function() { instant = false; });
 
   if (options.declaration) {
     addXmlDeclaration(options.declaration);


### PR DESCRIPTION
As far as I can see, this was leftover code which didn't actually do anything on its own, just set a state variable which is no longer used.