### PR TITLE
Fix #121 Improve enum support in response example generation.

### DIFF
--- a/src/styles/schema-styles.js
+++ b/src/styles/schema-styles.js
@@ -56,7 +56,7 @@ export default css`
 .inte, .integer, .numb, .number, .int6, .int64, .int3, .int32, .floa, .float, .doub, .double, .deci, .decimal, .blue { color:var(--blue); }
 .null { color:var(--red); }
 .bool, .boolean { color:var(--orange); }
-[class$="enum"], .cons, .const { color:var(--yellow); }
+.enum, .cons, .const { color:var(--yellow); }
 
 .tree .toolbar {
   display: flex;

--- a/src/styles/schema-styles.js
+++ b/src/styles/schema-styles.js
@@ -56,7 +56,7 @@ export default css`
 .inte, .integer, .numb, .number, .int6, .int64, .int3, .int32, .floa, .float, .doub, .double, .deci, .decimal, .blue { color:var(--blue); }
 .null { color:var(--red); }
 .bool, .boolean { color:var(--orange); }
-.enum, .cons, .const { color:var(--yellow); }
+[class$="enum"], .cons, .const { color:var(--yellow); }
 
 .tree .toolbar {
   display: flex;


### PR DESCRIPTION
Feel free to modify; I haven't tested extensively so I have probably missed some edge cases. Changes are to generate more accurate examples for types other than string.

Example response Model;
```
{
    a: string
    b: boolean
    c: number enum            Allowed: 111┃222
    d: email
    e: boolean enum           Allowed: true
    f: date
    g: number
    h: string enum            Allowed: some┃string
}
```

Example response Example;
```
{
    a: "a"
    b: false
    c: 111
    d: "user@example.com"
    e: true
    f: "2023-01-13"
    g: 0
    h: "some"
}
```
Test schema;
```json
{
  "openapi": "3.1.0",
  "paths": {
    "/example": {
      "get": {
        "responses": {
          "200": {
            "description": "Example response",
            "content": {
              "application/json": {
                "schema": {
                  "type": "obect",
                  "properties": {
                    "a": {
                      "type": "string",
                    },
                    "b": {
                      "type": "boolean",
                    },
                    "c": {
                      "type": "string",
                      "enum": [
                        111,
                        222
                      ]
                    },
                    "d": {
                      "type": "string"
                      "format": "email"
                    },
                    "e": {
                      "type": "boolean",
                      "enum": [
                        true
                      ]
                    },
                    "f": {
                      "type": "string",
                      "format": "date"
                    },
                    "g": {
                      "type": "number",
                    },
                    "h": {
                      "type": "string",
                      "type": "string",
                      "enum": [
                        "some",
                        "string"
                      ]
                    },
                  }
                }
              }
            }
          }
        }
      }
    }
  }
}
```