### PR TITLE
Display descriptions for URL parameters

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -210,6 +210,13 @@ export default class ApiRequest extends LitElement {
         ${this.renderStyle === 'focused'
           ? html`
             <td>
+              ${param.description
+                ? html`
+                  <div class="param-description">
+                      ${unsafeHTML(marked(param.description))}
+                  </div>`
+                : ''
+              }
               ${paramSchema.default || paramSchema.constraint || paramSchema.allowedValues || paramSchema.pattern
                 ? html`
                   <div class="param-constraint">

--- a/src/styles/api-request-styles.js
+++ b/src/styles/api-request-styles.js
@@ -32,6 +32,17 @@ export default css`
 .api-request .param-constraint:empty {
   display:none;
 }
+
+.api-request .param-description {
+  min-width:100px;
+}
+.api-request .param-description:empty {
+  display:none;
+}
+.api-request .param-description p {
+  margin-block: 0 0.5em;
+}
+
 .api-request .top-gap{margin-top:24px;}
 
 .api-request .textarea {


### PR DESCRIPTION
"Parameter Objects" in the OpenAPI spec can include a "description" property, which may include CommonMark formatting: https://spec.openapis.org/oas/latest.html#parameter-object