### PR TITLE
Add CSS variables controlling column widths in the "table" view

### DIFF
--- a/docs/styling.md
+++ b/docs/styling.md
@@ -16,6 +16,7 @@ The available variables are:
 Explorer location   | Variables
 --------------------|--------------------
 Fonts               | `--font-regular` `--font-mono`, `--font-size-small`, `--font-size-regular`, `--font-size-mono`
+Schema Table View   | `--schema-table-key-width`, `--schema-table-type-width`
 
 ### Directly amending classes
 While openapi-explorer uses a shadow DOM, it is easy to inject in CSS overrides to the existing styles. After creating the DOM element for the `openapi-explorer` using javascript you can:

--- a/src/components/schema-table.js
+++ b/src/components/schema-table.js
@@ -52,7 +52,7 @@ export default class SchemaTable extends LitElement {
         padding: 4px 0;
       }
       .table .key {
-        width: 240px;
+        width: var(--schema-table-key-width, 240px);
       }
       .key.deprecated .key-label {
         text-decoration: line-through;
@@ -60,7 +60,7 @@ export default class SchemaTable extends LitElement {
 
       .table .key-type {
         white-space: normal;
-        width: 150px;
+        width: var(--schema-table-type-width, 150px);
       }
 
       .key-type {


### PR DESCRIPTION
Depending on how deeply nested your schema is, and how long your property names, you might want to devote more (or less) width to the "key" column in the "table" view.

The easiest way to make this configurable seems to be with CSS variables, defaulting to the original width.