### PR TITLE
Don't use monospace font for property descriptions

### DIFF
--- a/src/components/schema-table.js
+++ b/src/components/schema-table.js
@@ -238,7 +238,7 @@ export default class SchemaTable extends LitElement {
         </div>
         <div class='td key-descr'>
           ${dataType === 'array' ? html`<span class="m-markdown-small">${unsafeHTML(marked(description))}</span>` : ''}
-          <span class="m-markdown-small" style="font-family: var(--font-mono); vertical-align: middle;">
+          <span class="m-markdown-small" style="vertical-align: middle;">
             ${unsafeHTML(marked(`${dataType === 'array' && description || `${schemaTitle ? `**${schemaTitle}:**` : ''} ${schemaDescription}` || ''}`))}
           </span>
           ${this.schemaDescriptionExpanded ? html`

--- a/src/components/schema-tree.js
+++ b/src/components/schema-tree.js
@@ -216,7 +216,7 @@ export default class SchemaTree extends LitElement {
             ${openBracket}
           </div>
           <div class="td key-descr">
-            <span class="m-markdown-small" style="font-family: var(--font-mono); vertical-align: middle;" title="${flags['🆁'] && 'Read only attribute' || flags['🆆'] && 'Write only attribute' || ''}">
+            <span class="m-markdown-small" style="vertical-align: middle;" title="${flags['🆁'] && 'Read only attribute' || flags['🆆'] && 'Write only attribute' || ''}">
               ${unsafeHTML(marked(displayLine))}
             </span>
           </div>
@@ -263,7 +263,7 @@ export default class SchemaTree extends LitElement {
 
         </div>
         <div class="td key-descr">
-          <span class="m-markdown-small" style="font-family: var(--font-mono); vertical-align: middle;" title="${readOrWriteOnly === '🆁' && 'Read only attribute' || readOrWriteOnly === '🆆' && 'Write only attribute' || ''}">
+          <span class="m-markdown-small" style="vertical-align: middle;" title="${readOrWriteOnly === '🆁' && 'Read only attribute' || readOrWriteOnly === '🆆' && 'Write only attribute' || ''}">
             ${unsafeHTML(marked(`${readOrWriteOnly && `${readOrWriteOnly} ` || ''}${dataType === 'array' && description || `${schemaTitle ? `**${schemaTitle}:**` : ''} ${schemaDescription}` || ''}`))}
           </span>
           ${this.schemaDescriptionExpanded ? html`


### PR DESCRIPTION
Currently, object and array property descriptions are in regular font, but others are forced to monospace with an inline style.

In my opinion, the monospace font looks ugly here, since descriptions are generally human-readable text, not code, so this PR removes the inline style.

However, if this is a desirable feature, let me know, and I will work on an alternative approach where all descriptions are styled consistently, and can be over-ridden in some way by the user.