### PR TITLE
Add path-details slot. fix #128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This package follows standard semvar, `<major>.<minor>.<build>`. No breaking cha
 * Fix deeply nested descriptions and property overrides.
 * Update yellow to purple for enums to provide better visibility on white backgrounds.
 * Fix handling of object-type header properties
+* Add the `path-details` slot and event subtype `OperationChanged`
 
 ## 0.11 ##
 * Fix `allOf` for response schema. #119

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -104,9 +104,10 @@ responseInterceptor(event) {
 
 ```js
 onEvent(event) {
-  // The User clicked the CLEAR button in the operation request section
   if (event.detail.type === 'RequestCleared') {
-
+    // The User clicked the CLEAR button in the operation request section
+  } else if (event.data.type === 'OperationChanged') {
+    // User navigated somewhere else
   }
 }
 ```
@@ -209,6 +210,13 @@ OpenAPI Explorer supports inline code samples using the `x-code-samples` OpenAPI
 <p>
   <img src="./code-samples.png" alt="Code Samples" width="600px">
 </p>
+
+### Determining where the user is
+Knowing exactly where the user is can be tricky. One way is add the event listener for the type `event`. Another way is to search for the open slot dedicated to the current path details. The `path-details` slot is dynamically rendered with the appropriate `method` and `path` data properties. You can pull these out by doing this:
+```js
+document.getElementsByTagName("openapi-explorer")[0].shadowRoot.querySelectorAll('slot[name=path-details]')[0].attributes['data-method'].value;
+document.getElementsByTagName("openapi-explorer")[0].shadowRoot.querySelectorAll('slot[name=path-details]')[0].attributes['data-path'].value;
+```
 
 ### Styling using CSS variables
 In many cases these might have already been set by your css framework, if not, and you want to override the the defaults to match your theme. For more in-depth options check out [How to style your openapi-explorer UI](./styling.md).

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -108,6 +108,7 @@ onEvent(event) {
     // The User clicked the CLEAR button in the operation request section
   } else if (event.data.type === 'OperationChanged') {
     // User navigated somewhere else
+    console.log(event.data.operation);
   }
 }
 ```

--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -544,7 +544,7 @@ export default class ApiRequest extends LitElement {
     const requestPanelInputEls = [...requestPanelEl.querySelectorAll('input, tag-input, textarea:not(.is-hidden)')];
     requestPanelInputEls.forEach((el) => { el.value = ''; });
 
-    const event = { bubbles: true, composed: true, detail: { explorerLocation: this.elementId, type: 'RequestCleared' } };
+    const event = { bubbles: true, composed: true, detail: { explorerLocation: this.elementId, method: this.method, path: this.path, type: 'RequestCleared' } };
     this.dispatchEvent(new CustomEvent('event', event));
   }
 

--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -544,7 +544,7 @@ export default class ApiRequest extends LitElement {
     const requestPanelInputEls = [...requestPanelEl.querySelectorAll('input, tag-input, textarea:not(.is-hidden)')];
     requestPanelInputEls.forEach((el) => { el.value = ''; });
 
-    const event = { bubbles: true, composed: true, detail: { explorerLocation: this.elementId, method: this.method, path: this.path, type: 'RequestCleared' } };
+    const event = { bubbles: true, composed: true, detail: { explorerLocation: this.elementId, operation: { method: this.method, path: this.path }, type: 'RequestCleared' } };
     this.dispatchEvent(new CustomEvent('event', event));
   }
 

--- a/src/openapi-explorer.js
+++ b/src/openapi-explorer.js
@@ -604,7 +604,7 @@ export default class OpenApiExplorer extends LitElement {
     let isExpandingNeeded = false;
     
     const tag = this.resolvedSpec.tags.find(t => t.paths && t.paths.find(p => p.elementId === elementId));
-    const path = tag && tag.paths && tag.paths.find((p) => p.elementId === elementId);
+    const path = tag?.paths?.find((p) => p.elementId === elementId);
     if (path && (!path.expanded || !tag.expanded)) {
       isExpandingNeeded = true;
       path.expanded = true;
@@ -740,6 +740,10 @@ export default class OpenApiExplorer extends LitElement {
     if (!this.resolvedSpec) {
       return;
     }
+
+    const data = this.resolvedSpec.tags.map(t => t.paths).flat(1).find(p => p.elementId === elementId);
+    const event = { bubbles: true, composed: true, detail: { explorerLocation: elementId, method: data?.method, path: data?.path, type: 'OperationChanged' } };
+    this.dispatchEvent(new CustomEvent('event', event));
 
     if (this.renderStyle === 'view') {
       this.expandAndGotoOperation(elementId);

--- a/src/openapi-explorer.js
+++ b/src/openapi-explorer.js
@@ -741,9 +741,7 @@ export default class OpenApiExplorer extends LitElement {
       return;
     }
 
-    const data = this.resolvedSpec.tags.map(t => t.paths).flat(1).find(p => p.elementId === elementId);
-    const event = { bubbles: true, composed: true, detail: { explorerLocation: elementId, method: data?.method, path: data?.path, type: 'OperationChanged' } };
-    this.dispatchEvent(new CustomEvent('event', event));
+    this.emitOperationChangedEvent(elementId);
 
     if (this.renderStyle === 'view') {
       this.expandAndGotoOperation(elementId);
@@ -833,6 +831,12 @@ export default class OpenApiExplorer extends LitElement {
       const searchOptions = [...eventTargetEl.closest('.advanced-search-options').querySelectorAll('input:checked')].map((v) => v.id);
       this.advancedSearchMatches = advancedSearch(searchInputEl.value, this.resolvedSpec.tags, searchOptions);
     }, 0);
+  }
+
+  emitOperationChangedEvent(elementId) {
+    const operation = this.resolvedSpec.tags.map(t => t.paths).flat(1).find(p => p.elementId === elementId);
+    const event = { bubbles: true, composed: true, detail: { explorerLocation: elementId, operation, type: 'OperationChanged' } };
+    this.dispatchEvent(new CustomEvent('event', event));
   }
 }
 

--- a/src/templates/endpoint-template.js
+++ b/src/templates/endpoint-template.js
@@ -10,12 +10,11 @@ import { getCurrentElement, pathIsInSearch, replaceState } from '../utils/common
 
 function toggleExpand(path) {
   if (path.expanded) {
-    path.expanded = false; // collapse
+    path.expanded = false;
     replaceState(null);
   } else {
-    path.expanded = true; // Expand
-    const event = { bubbles: true, composed: true, detail: { explorerLocation: path.elementId, method: path.method, path: path.path, type: 'OperationChanged' } };
-    this.dispatchEvent(new CustomEvent('event', event));
+    path.expanded = true;
+    this.emitOperationChangedEvent(path.elementId);
 
     // Toggle all the other ones off
     this.resolvedSpec.tags.forEach(t => t.paths.filter(p => p.elementId !== path.elementId).forEach(p => p.expanded = false));

--- a/src/templates/endpoint-template.js
+++ b/src/templates/endpoint-template.js
@@ -14,6 +14,11 @@ function toggleExpand(path) {
     replaceState(null);
   } else {
     path.expanded = true; // Expand
+    const event = { bubbles: true, composed: true, detail: { explorerLocation: path.elementId, method: path.method, path: path.path, type: 'OperationChanged' } };
+    this.dispatchEvent(new CustomEvent('event', event));
+
+    // Toggle all the other ones off
+    this.resolvedSpec.tags.forEach(t => t.paths.filter(p => p.elementId !== path.elementId).forEach(p => p.expanded = false));
     if (path.elementId !== getCurrentElement()) {
       replaceState(path.elementId);
     }
@@ -22,32 +27,13 @@ function toggleExpand(path) {
 }
 
 function toggleTag(tagElement, tagId) {
-  const sectionTag = tagElement.target.closest('.section-tag');
   const tag = this.resolvedSpec.tags.find(t => t.elementId === tagId);
   tag.expanded = !tag.expanded;
-  if (tag.expanded) {
-    sectionTag.classList.remove('collapsed');
-    sectionTag.classList.add('expanded');
-  } else {
-    sectionTag.classList.remove('expanded');
-    sectionTag.classList.add('collapsed');
-  }
   this.requestUpdate();
 }
-export function expandCollapseAll(currentElement, action = 'expand-all') {
-  const operationsRootEl = currentElement.target.closest('.operations-root');
-  const elList = [...operationsRootEl.querySelectorAll('.section-tag')];
-  const expand = action === 'expand-all';
+export function expandCollapseAll(currentElement, expand) {
   this.resolvedSpec.tags.forEach(t => t.expanded = expand);
-  elList.map((el) => {
-    if (expand) {
-      el.classList.remove('collapsed');
-      el.classList.add('expanded');
-    } else {
-      el.classList.remove('expanded');
-      el.classList.add('collapsed');
-    }
-  });
+  this.requestUpdate();
 }
 
 /* eslint-disable indent */
@@ -69,13 +55,13 @@ function endpointHeadTemplate(path) {
 function endpointBodyTemplate(path) {
   const acceptContentTypes = new Set();
   for (const respStatus in path.responses) {
-    for (const acceptContentType in path.responses[respStatus] && path.responses[respStatus].content) {
+    for (const acceptContentType in path.responses[respStatus]?.content) {
       acceptContentTypes.add(acceptContentType.trim());
     }
   }
   const accept = [...acceptContentTypes].join(', ');
   // Filter API Keys that are non-empty and are applicable to the the path
-  const nonEmptyApiKeys = this.resolvedSpec.securitySchemes.filter((v) => (v.finalKeyValue && path.security && path.security.some((ps) => ps[v.apiKeyId]))) || [];
+  const nonEmptyApiKeys = this.resolvedSpec.securitySchemes.filter((v) => (v.finalKeyValue && path.security?.some((ps) => ps[v.apiKeyId]))) || [];
 
   const codeSampleTabPanel = path.xCodeSamples ? codeSamplesTemplate(path.xCodeSamples) : '';
   return html`
@@ -92,6 +78,7 @@ function endpointBodyTemplate(path) {
       }
       ${path.description ? html`<div class="m-markdown"> ${unsafeHTML(marked(path.description))}</div>` : ''}
       <slot name="${path.elementId}"></slot>
+      <slot name="path-details" data-method="${path.method}" data-path="${path.path}"></slot>
       ${pathSecurityTemplate.call(this, path.security)}
       ${codeSampleTabPanel}
     </div>  
@@ -140,9 +127,9 @@ function endpointBodyTemplate(path) {
 export default function endpointTemplate() {
   return html`
     <div style="display:flex; justify-content:flex-end; padding-right: 1rem; font-size: 14px; margin-top: 16px;"> 
-      <span @click="${(e) => expandCollapseAll.call(this, e, 'expand-all')}" style="color:var(--primary-color); cursor: pointer;">Expand</span> 
+      <span @click="${(e) => expandCollapseAll.call(this, e, true)}" style="color:var(--primary-color); cursor: pointer;">Expand</span> 
       &nbsp;|&nbsp; 
-      <span @click="${(e) => expandCollapseAll.call(this, e, 'collapse-all')}" style="color:var(--primary-color); cursor: pointer;">Collapse</span>
+      <span @click="${(e) => expandCollapseAll.call(this, e, false)}" style="color:var(--primary-color); cursor: pointer;">Collapse</span>
     </div>
     ${(this.resolvedSpec && this.resolvedSpec.tags || []).map((tag) => html`
     <div class='regular-font method-section-gap section-tag ${tag.expanded ? 'expanded' : 'collapsed'}'> 

--- a/src/templates/expanded-endpoint-template.js
+++ b/src/templates/expanded-endpoint-template.js
@@ -44,6 +44,7 @@ export function expandedEndpointBodyTemplate(path, tagName = '') {
     </div>
     <div class="m-markdown" style="margin-right: 2rem;"> ${unsafeHTML(marked(path.description || ''))}</div>
     <slot name="${path.elementId}"></slot>
+    <slot name="path-details" data-method="${path.method}" data-path="${path.path}"></slot>
     ${pathSecurityTemplate.call(this, path.security)}
     ${codeSampleTabPanel}
     <div class='expanded-req-resp-container'>

--- a/src/utils/spec-parser.js
+++ b/src/utils/spec-parser.js
@@ -31,7 +31,7 @@ export default async function ProcessSpec(specUrlOrObject, serverUrl = '') {
 
   // Security Scheme
   const securitySchemes = [];
-  if (jsonParsedSpec.components && jsonParsedSpec.components.securitySchemes) {
+  if (jsonParsedSpec.components?.securitySchemes) {
     Object.entries(jsonParsedSpec.components.securitySchemes).forEach((kv) => {
       const securityObj = { apiKeyId: kv[0], ...kv[1] };
       securityObj.value = '';
@@ -277,10 +277,9 @@ function groupByTags(openApiSpec) {
           }
 
           // Update Responses
-          tagObj.paths.push({
+          const pathObject = {
             expanded: false,
             isWebhook,
-            expandedAtLeastOnce: false,
             summary: (pathOrHookObj.summary || ''),
             description: (pathOrHookObj.description || ''),
             shortSummary,
@@ -298,8 +297,13 @@ function groupByTags(openApiSpec) {
             externalDocs: pathOrHookObj.externalDocs,
             // commonSummary: commonPathProp.summary,
             // commonDescription: commonPathProp.description,
-            xCodeSamples: pathOrHookObj['x-codeSamples'] || pathOrHookObj['x-code-samples'] || '',
-          });
+            xCodeSamples: pathOrHookObj['x-code-samples'] || '',
+            extensions: Object.keys(pathOrHookObj).filter(k => k.startsWith('x-') && k !== 'x-code-samples').reduce((acc, extensionKey) => {
+              acc[extensionKey] = pathOrHookObj[extensionKey];
+              return acc;
+            }, {})
+          };
+          tagObj.paths.push(pathObject);
         });// End of tag path create
       }
     }); // End of Methods


### PR DESCRIPTION
Provide a new slot that always displays in every operation documentation as well as providing an event to trigger on `OperationChanged`.