### PR TITLE
Use animation rather than transition to avoid arbritrary max-height

### DIFF
--- a/src/components/json-tree.js
+++ b/src/components/json-tree.js
@@ -55,13 +55,30 @@ export default class JsonTree extends LitElement {
         border: 1px solid var(--border-color);
       }
 
+      /* Expand a block from 0 to something visible, then to probably full screen, then beyond most screens.
+         Unlike with a transition, the final CSS can have an unbounded height, which will take effect after the animation. */
+      @keyframes expand-height {
+        0% { max-height: 0; }
+        50% { max-height: 100px; }
+        95% { max-height: 1000px; }
+        100% { max-height: 5000px; }
+      }
+      /* Inverse of the above, collapsing quickly at first (to avoid a delay if the element is already quite short)
+         then slowing towards 0. */
+      @keyframes collapse-height {
+        0% { max-height: 5000px; }
+        5% { max-height: 500px; }
+        50% { max-height: 100px; }
+        100% { max-height: 0; }
+      }
       .inside-bracket-wrapper {
-        max-height: 10000px;
-        transition: max-height 1.2s ease-in-out;
         overflow: hidden;
       }
+      .open-bracket:not(.collapsed) + .inside-bracket-wrapper {
+        animation: linear 0.2s expand-height;
+      }
       .open-bracket.collapsed + .inside-bracket-wrapper {
-        transition: max-height 1.2s ease-in-out -1.1s;
+        animation: linear 0.2s collapse-height;
         max-height: 0;
       }
       .inside-bracket {

--- a/src/components/json-tree.js
+++ b/src/components/json-tree.js
@@ -4,6 +4,7 @@ import { getI18nText } from '../languages';
 import FontStyles from '../styles/font-styles.js';
 import BorderStyles from '../styles/border-styles';
 import InputStyles from '../styles/input-styles';
+import KeyFrameStyles from '../styles/key-frame-styles.js';
 
 export default class JsonTree extends LitElement {
   static get properties() {
@@ -18,6 +19,7 @@ export default class JsonTree extends LitElement {
       FontStyles,
       BorderStyles,
       InputStyles,
+      KeyFrameStyles,
       css`
       :host{
         display:flex;
@@ -55,22 +57,6 @@ export default class JsonTree extends LitElement {
         border: 1px solid var(--border-color);
       }
 
-      /* Expand a block from 0 to something visible, then to probably full screen, then beyond most screens.
-         Unlike with a transition, the final CSS can have an unbounded height, which will take effect after the animation. */
-      @keyframes expand-height {
-        0% { max-height: 0; }
-        50% { max-height: 100px; }
-        95% { max-height: 1000px; }
-        100% { max-height: 5000px; }
-      }
-      /* Inverse of the above, collapsing quickly at first (to avoid a delay if the element is already quite short)
-         then slowing towards 0. */
-      @keyframes collapse-height {
-        0% { max-height: 5000px; }
-        5% { max-height: 500px; }
-        50% { max-height: 100px; }
-        100% { max-height: 0; }
-      }
       .inside-bracket-wrapper {
         overflow: hidden;
       }

--- a/src/components/schema-table.js
+++ b/src/components/schema-table.js
@@ -73,13 +73,17 @@ export default class SchemaTable extends LitElement {
         font-family: var(--font-mono);
         background-clip: border-box;
       }
+
+
+        
       .tr + .object-body {
-        max-height: 5000px;
-        transition: max-height 1.2s ease-in-out;
         overflow: hidden;
+      } 
+      .tr:not(.collapsed) + .object-body {
+        animation: linear 0.2s expand-height;
       }
       .tr.collapsed + .object-body {
-        transition: max-height 1.2s ease-in-out -1.0s;
+        animation: linear 0.2s collapse-height;
         max-height: 0;
       }
       .obj-toggle {

--- a/src/components/schema-table.js
+++ b/src/components/schema-table.js
@@ -3,6 +3,7 @@ import { marked } from 'marked';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import FontStyles from '../styles/font-styles.js';
 import SchemaStyles from '../styles/schema-styles';
+import KeyFrameStyles from '../styles/key-frame-styles.js';
 
 const tablePadding = 16;
 const firstColumnInitialPadding = tablePadding * 2;
@@ -29,6 +30,7 @@ export default class SchemaTable extends LitElement {
   static finalizeStyles() {
     return [
       FontStyles,
+      KeyFrameStyles,
       SchemaStyles,
       css`
       .table {
@@ -73,9 +75,6 @@ export default class SchemaTable extends LitElement {
         font-family: var(--font-mono);
         background-clip: border-box;
       }
-
-
-        
       .tr + .object-body {
         overflow: hidden;
       } 

--- a/src/components/schema-tree.js
+++ b/src/components/schema-tree.js
@@ -5,6 +5,7 @@ import { getI18nText } from '../languages';
 import FontStyles from '../styles/font-styles.js';
 import SchemaStyles from '../styles/schema-styles';
 import BorderStyles from '../styles/border-styles';
+import KeyFrameStyles from '../styles/key-frame-styles.js';
 
 export default class SchemaTree extends LitElement {
   static get properties() {
@@ -30,6 +31,7 @@ export default class SchemaTree extends LitElement {
       FontStyles,
       SchemaStyles,
       BorderStyles,
+      KeyFrameStyles,
       css`
       .tree {
         min-height: 30px;

--- a/src/components/schema-tree.js
+++ b/src/components/schema-tree.js
@@ -72,12 +72,13 @@ export default class SchemaTree extends LitElement {
       }
 
       .inside-bracket-wrapper {
-        max-height: 10000px;
-        transition: max-height 1.2s ease-in-out;
         overflow: hidden;
       }
+      .tr:not(.collapsed) + .inside-bracket-wrapper {
+        animation: linear 0.2s expand-height;
+      }
       .tr.collapsed + .inside-bracket-wrapper {
-        transition: max-height 1.2s ease-in-out -1.1s;
+        animation: linear 0.2s collapse-height;
         max-height: 0;
       }
 

--- a/src/openapi-explorer.js
+++ b/src/openapi-explorer.js
@@ -21,6 +21,7 @@ import InputStyles from './styles/input-styles';
 import SchemaStyles from './styles/schema-styles';
 import FlexStyles from './styles/flex-styles';
 import TableStyles from './styles/table-styles';
+import KeyFrameStyles from './styles/key-frame-styles';
 import EndpointStyles from './styles/endpoint-styles';
 import PrismStyles from './styles/prism-styles';
 import TabStyles from './styles/tab-styles';
@@ -125,6 +126,7 @@ export default class OpenApiExplorer extends LitElement {
       InputStyles,
       FlexStyles,
       TableStyles,
+      KeyFrameStyles,
       EndpointStyles,
       PrismStyles,
       TabStyles,
@@ -295,11 +297,6 @@ export default class OpenApiExplorer extends LitElement {
       .tooltip:hover .tooltip-text {
         visibility: visible;
         opacity: 1;
-      }
-
-      @keyframes spin {
-        0% { transform: rotate(0deg); }
-        100% { transform: rotate(360deg); }
       }
 
       @media only screen and (max-width: 767.98px) {

--- a/src/styles/key-frame-styles.js
+++ b/src/styles/key-frame-styles.js
@@ -1,0 +1,25 @@
+import { css } from 'lit';
+
+export default css`
+  @keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+  }
+
+  /* Expand a block from 0 to something visible, then to probably full screen, then beyond most screens.
+     Unlike with a transition, the final CSS can have an unbounded height, which will take effect after the animation. */
+  @keyframes expand-height {
+    0% { max-height: 0; }
+    50% { max-height: 100px; }
+    95% { max-height: 1000px; }
+    100% { max-height: 5000px; }
+  }
+  /* Inverse of the above, collapsing quickly at first (to avoid a delay if the element is already quite short)
+     then slowing towards 0. */
+  @keyframes collapse-height {
+    0% { max-height: 5000px; }
+    5% { max-height: 500px; }
+    50% { max-height: 100px; }
+    100% { max-height: 0; }
+  }
+`;

--- a/src/styles/key-frame-styles.js
+++ b/src/styles/key-frame-styles.js
@@ -6,20 +6,25 @@ export default css`
     100% { transform: rotate(360deg); }
   }
 
-  /* Expand a block from 0 to something visible, then to probably full screen, then beyond most screens.
-     Unlike with a transition, the final CSS can have an unbounded height, which will take effect after the animation. */
+  /* 
+    Expand a block smoothly to 100px, then to fill the current viewport.
+    Unlike with a transition, the final CSS can have an unbounded height, which will take effect after the animation.
+    Simultaneously fades in, mostly for symmetry with the collapse animation below.
+  */
   @keyframes expand-height {
-    0% { max-height: 0; }
-    50% { max-height: 100px; }
-    95% { max-height: 1000px; }
-    100% { max-height: 5000px; }
+    0% { max-height: 0; opacity: 0; }
+    50% { max-height: 100px; opacity: 100%; }
+    100% { max-height: 100lvh; }
   }
-  /* Inverse of the above, collapsing quickly at first (to avoid a delay if the element is already quite short)
-     then slowing towards 0. */
+  /*
+    Rough inverse of the above - animate from a maximum of full viewport height down to zero.
+    Since most elements will already be smaller than the viewport, most of the animation time is spent on the last 100px.
+    Simultaneously fades the content out, so that some visible animation starts immediately even for very short elements. 
+   */
   @keyframes collapse-height {
-    0% { max-height: 5000px; }
-    5% { max-height: 500px; }
-    50% { max-height: 100px; }
-    100% { max-height: 0; }
+    0% { max-height: 500lvh; opacity: 100%; }
+    5% { max-height: 50lvh; }
+    40% { max-height: 100px; opacity: 25%; }
+    100% { max-height: 0; opacity: 0; }
   }
 `;

--- a/src/styles/schema-styles.js
+++ b/src/styles/schema-styles.js
@@ -95,6 +95,22 @@ export default css`
 }
 .toolbar-item:first-of-type { margin:0 2px 0 0;}
 
+/* Expand a block from 0 to something visible, then to probably full screen, then beyond most screens.
+   Unlike with a transition, the final CSS can have an unbounded height, which will take effect after the animation. */
+@keyframes expand-height {
+  0% { max-height: 0; }
+  50% { max-height: 100px; }
+  95% { max-height: 1000px; }
+  100% { max-height: 5000px; }
+}
+/* Inverse of the above, collapsing quickly at first (to avoid a delay if the element is already quite short)
+   then slowing towards 0. */
+@keyframes collapse-height {
+  0% { max-height: 5000px; }
+  5% { max-height: 500px; }
+  50% { max-height: 100px; }
+  100% { max-height: 0; }
+}
 
 @media only screen and (min-width: 576px) {
   .key-descr {

--- a/src/styles/schema-styles.js
+++ b/src/styles/schema-styles.js
@@ -95,22 +95,6 @@ export default css`
 }
 .toolbar-item:first-of-type { margin:0 2px 0 0;}
 
-/* Expand a block from 0 to something visible, then to probably full screen, then beyond most screens.
-   Unlike with a transition, the final CSS can have an unbounded height, which will take effect after the animation. */
-@keyframes expand-height {
-  0% { max-height: 0; }
-  50% { max-height: 100px; }
-  95% { max-height: 1000px; }
-  100% { max-height: 5000px; }
-}
-/* Inverse of the above, collapsing quickly at first (to avoid a delay if the element is already quite short)
-   then slowing towards 0. */
-@keyframes collapse-height {
-  0% { max-height: 5000px; }
-  5% { max-height: 500px; }
-  50% { max-height: 100px; }
-  100% { max-height: 0; }
-}
 
 @media only screen and (min-width: 576px) {
   .key-descr {


### PR DESCRIPTION
For requests and repsonses with a lot of properties, the schema and examples are currently truncated, because the containing elements have max-height set to 5000px or 10000px.

This value is part of the expand/collapse transition - animating from zero to 'auto' turns out to be a hard problem, as discussed in this Stack Overflow question: https://stackoverflow.com/q/3508605/157957

This patch takes an alternative approach: using "animation" rather than "transition", the last frame of the animation can have a max-height, but then revert to auto. The "snap" to full height will happen off-screen, unless your screen is more than 5000px tall.

This also allows a slightly more natural collapse transition, quickly collapsing long blocks, so that shorter blocks don't have an awkward pause before they start animating.