### PR TITLE
Use default fg and bg2 CSS variables in json-tree and schema-tree

### DIFF
--- a/src/components/json-tree.js
+++ b/src/components/json-tree.js
@@ -25,8 +25,7 @@ export default class JsonTree extends LitElement {
         display:flex;
       }
       .json-tree {
-        background: var(--primary-color);
-        color: white;
+        background: var(--bg2);
         padding: 12px;
 
         min-height: 30px;
@@ -76,7 +75,6 @@ export default class JsonTree extends LitElement {
       .number{color:var(--blue);}
       .null{color:var(--red);}
       .boolean{color:var(--orange);}
-      .object{color:white}
 
       .toolbar {
         display: none;

--- a/src/components/schema-tree.js
+++ b/src/components/schema-tree.js
@@ -35,9 +35,8 @@ export default class SchemaTree extends LitElement {
       css`
       .tree {
         min-height: 30px;
-        background: var(--primary-color);
+        background: var(--bg2);
         padding: 12px;
-        color: white;
         font-size:var(--font-size-small);
         text-align: left;
         line-height:calc(var(--font-size-small) + 6px);


### PR DESCRIPTION
Fixed #144. By removing the color property it will inherit --fg from host instead. Also remove the color property from object, otherwise the opening curly bracket will have the wrong color. 

Before change:
![before1](https://user-images.githubusercontent.com/8858497/230071119-ebbc84f8-082b-4931-98bf-39a4d724084b.png)

After change:
![after1](https://user-images.githubusercontent.com/8858497/230071117-f961b87d-0590-42c4-a329-dcb6db8b572d.png)