### PR TITLE
Enable tags which can be used for documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This package follows standard semvar, `<major>.<minor>.<build>`. No breaking cha
 * Fix initial padding for non-object based field properties, by setting the min at 32px (or 2 * the shift which is 16px)
 * Ensure UI recordings do not include curl command which might include security tokens
 * Fix table layout so that the path parameters table has a wider input area.
+* Don't filter out tags that have no paths, no-path tags can be used for documentation.
 
 ## 0.11 ##
 * Fix `allOf` for response schema. #119

--- a/mocks/index-schema.json
+++ b/mocks/index-schema.json
@@ -9,6 +9,7 @@
             "email": "support@test.com"
         }
     },
+    "tags": [{ "name": "Example Tag", "description": "# Example tag description\n## Sub Menu example" }],
     "servers": [
         {
             "url": "https://testserver:{port}/",
@@ -169,7 +170,7 @@
                             },
                             "testdate2": {
                                 "type": "string",
-                                "format": "date"
+                                "format": "byte"
                             }
                         }
                     }

--- a/src/templates/navbar-template.js
+++ b/src/templates/navbar-template.js
@@ -87,7 +87,7 @@ export default function navbarTemplate() {
             <div class='nav-bar-section-title'>${getI18nText('menu.operations')}</div>  
           </slot>
           <div style="" part="navbar-operations-header-collapse">
-            ${this.resolvedSpec.tags.length > 1 && this.resolvedSpec.tags.some((tag) => tag.paths.some((path) => pathIsInSearch(this.matchPaths, path)))
+            ${this.resolvedSpec.tags.length > 1 && this.resolvedSpec.tags.some((tag) => !tag.paths.length && !this.matchPaths || tag.paths.some((path) => pathIsInSearch(this.matchPaths, path)))
               ? html`
                 <div class="toggle">▾</div>`
               : ''
@@ -98,7 +98,7 @@ export default function navbarTemplate() {
 
       <!-- TAGS AND PATHS-->
       ${this.resolvedSpec.tags
-        .filter((tag) => tag.paths.some((path) => pathIsInSearch(this.matchPaths, path)))
+        .filter((tag) => !tag.paths.length && !this.matchPaths || tag.paths.some((path) => pathIsInSearch(this.matchPaths, path)))
         .map((tag) => html`
           <slot name="nav-${tag.elementId}">
             <div class='nav-bar-tag-and-paths ${tag.expanded ? '' : 'collapsed'}'>

--- a/src/utils/spec-parser.js
+++ b/src/utils/spec-parser.js
@@ -226,7 +226,7 @@ function groupByTags(openApiSpec) {
           let specTagsItem;
 
           if (openApiSpec.tags) {
-            specTagsItem = openApiSpec.tags.find((v) => (v.name.toLowerCase() === tag.toLowerCase()));
+            specTagsItem = tags.find((v) => (v.name.toLowerCase() === tag.toLowerCase()));
           }
 
           tagObj = tags.find((v) => v.name === tag);
@@ -309,5 +309,5 @@ function groupByTags(openApiSpec) {
     }); // End of Methods
   }
 
-  return tags.filter((tag) => tag.paths && tag.paths.length > 0);
+  return tags;
 }


### PR DESCRIPTION
fyi @sanscontext , @jmlothian
We thought this was a great idea in our fork here, so we've added this in. Now tags without paths will be displayed as expected.

Also for what its worth, we've also have included an alternative solution that works by injecting in sections above the **Operations** section:

![image](https://github.com/Rhosys/openapi-explorer/assets/5056218/275b7bfe-2854-46b1-945d-ede12c63d55b)


You can see how we've put in `Pagination` into our spec over at: https://authress.io/app/#/api?route=section--1
The code do that was:
```html
<div slot="nav-section">Pagination</div>
      <div slot="custom-section">
        <div class="d-panel d-panel-body">
          <h2>Pagination</h2>
          <div>The Authress API has multiple collection based resources. These resources are retrieved using the associated <strong>GET</strong> methods on the
            <code>/collection-name</code> resource. An example of a collection resource is the
            <b-link @click="() => explorerLocation = 'get-/v1/users/-userId-/resources'">List user resources</b-link>.
            <br><br>
            The <strong>List user resources</strong> endpoint and other collection endpoints return a response object which contains the collection list as well as a pagination object
            when they collection is larger than the response limit.
            To retrieve these additional collection results, utilize the <code>cursor</code> returned by passing it as a query parameter to the collection endpoint.

            <div class="group bg-horizon py-2 px-4 m-3" style="border-radius: 10px">
              <h4 class="mt-2">Response:</h4>
              <!-- eslint-disable-next-line vue/no-v-html -->
              <small><pre><div v-html="sdkResponseExampleHtml" /></pre></small>
            </div>

            <div class="group bg-horizon py-2 px-4 m-3" style="border-radius: 10px">
              <h4 class="mt-2">Paginated Query:</h4>
              <!-- eslint-disable-next-line vue/no-v-html -->
              <small><pre><div v-html="sdkPaginatedQueryExampleHtml" /></pre></small>
            </div>

            <div>For SDK specific usage, see the relevant <b-link @click="() => explorerLocation = 'overview'">Authress SDK documentation</b-link>.</div>
          </div>
        </div>
      </div>
```

I hope this helps in some way!

