### PR TITLE
Fix api-request leaking state when changing paths.

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -411,7 +411,8 @@ export default class ApiRequest extends LitElement {
       `;
 
     // For Loop - Main
-    const reqBody = requestBodyTypes.find(req => req.mimeType === this.selectedRequestBodyType);
+    const reqBody = requestBodyTypes.find(req => req.mimeType === this.selectedRequestBodyType) || requestBodyTypes[0];
+    this.selectedRequestBodyType = reqBody.mimeType; // Ensure that the selected type exists.
     // Generate Example
     if (this.selectedRequestBodyType.includes('json') || this.selectedRequestBodyType.includes('xml') || this.selectedRequestBodyType.includes('text')) {
       const reqBodyExamples = generateExample(


### PR DESCRIPTION
Reproduction:
1. Given two path items with mutually exclusive sets of mimeTypes,
```js
{ paths: {
  "/foo": {
    "post": {
      "requestBody": {
        "content": {
          "application/octet-stream": {}
        }
      }
    },
    "put": {
      "requestBody": {
        "content": {
          "application/json": {}
        }
      }
    }
  }
}}
```
2. Navigate between them. You'll see errors in the JS console. The UI has no problems.

The error indicates that the `reqBody` is undefined, because it was searching for the incorrect `selectedRequestBodyType` in `requestBodyTypes`. This fix is just patching it so that, if it fails to find the "selected" requestBodyType, it simply picks one that at least exists.