### PR TITLE
Fix animations on schema viewer

### DIFF
--- a/src/components/json-tree.js
+++ b/src/components/json-tree.js
@@ -14,6 +14,20 @@ export default class JsonTree extends LitElement {
     };
   }
 
+  /**
+   * @param {Map<string, object>} changedProperties Changed Properties
+   */
+  update(changedProperties) {
+    if (changedProperties.has('data')) {
+      this.interactive = false;
+    }
+    super.update(changedProperties);
+  }
+
+  updated() {
+    this.interactive = true; // Note: interactive is not a reactive property
+  }
+
   static finalizeStyles() {
     return [
       FontStyles,
@@ -58,6 +72,9 @@ export default class JsonTree extends LitElement {
 
       .inside-bracket-wrapper {
         overflow: hidden;
+      }
+      .tree:not(.interactive) .inside-bracket-wrapper {
+        animation-duration: 0s !important;
       }
       .open-bracket:not(.collapsed) + .inside-bracket-wrapper {
         animation: linear 0.2s expand-height;
@@ -134,7 +151,7 @@ export default class JsonTree extends LitElement {
   /* eslint-disable indent */
   render() {
     return html`
-      <div class="json-tree tree">
+      <div class="json-tree tree ${this.interactive ? 'interactive' : ''}">
         <div class="toolbar"> 
           <div>&nbsp;</div>
           <div class="toolbar-item">

--- a/src/components/schema-table.js
+++ b/src/components/schema-table.js
@@ -25,6 +25,20 @@ export default class SchemaTable extends LitElement {
     if (!this.schemaHideWriteOnly || !'true false'.includes(this.schemaHideWriteOnly)) { this.schemaHideWriteOnly = 'true'; }
   }
 
+  /**
+   * @param {Map<string, object>} changedProperties Changed Properties
+   */
+  update(changedProperties) {
+    if (changedProperties.has('data')) {
+      this.interactive = false;
+    }
+    super.update(changedProperties);
+  }
+
+  updated() {
+    this.interactive = true; // Note: interactive is not a reactive property
+  }
+
   static finalizeStyles() {
     return [
       FontStyles,
@@ -76,6 +90,9 @@ export default class SchemaTable extends LitElement {
       .tr + .object-body {
         overflow: hidden;
       } 
+      .table:not(.interactive) .object-body {
+        animation-duration: 0s !important;
+      }
       .tr:not(.collapsed) + .object-body {
         animation: linear 0.2s expand-height;
       }
@@ -100,7 +117,7 @@ export default class SchemaTable extends LitElement {
         ? html`<span class='m-markdown' style="padding-bottom: 8px;"> ${unsafeHTML(marked(this.data['::description'] || ''))}</span>`
         : ''
       }
-      <div class="table">
+      <div class="table ${this.interactive ? 'interactive' : ''}">
         <div style = 'border:1px solid var(--light-border-color)'>
           <div style='display:flex; background-color: var(--bg2); padding:8px 4px; border-bottom:1px solid var(--light-border-color);'>
             <div class='key' style='font-family:var(--font-regular); font-weight:bold; color:var(--fg); padding-left:${firstColumnInitialPadding}px'> Field </div>

--- a/src/components/schema-tree.js
+++ b/src/components/schema-tree.js
@@ -26,6 +26,20 @@ export default class SchemaTree extends LitElement {
     if (!this.schemaHideWriteOnly || !'true false'.includes(this.schemaHideWriteOnly)) { this.schemaHideWriteOnly = 'true'; }
   }
 
+  /**
+   * @param {Map<string, object>} changedProperties Changed Properties
+   */
+  update(changedProperties) {
+    if (changedProperties.has('data')) {
+      this.interactive = false;
+    }
+    super.update(changedProperties);
+  }
+
+  updated() {
+    this.interactive = true; // Note: interactive is not a reactive property
+  }
+
   static finalizeStyles() {
     return [
       FontStyles,
@@ -41,7 +55,7 @@ export default class SchemaTree extends LitElement {
         text-align: left;
         line-height:calc(var(--font-size-small) + 6px);
       }
-
+      
       .tree .key {
         max-width: 300px;
       }
@@ -75,6 +89,9 @@ export default class SchemaTree extends LitElement {
       .inside-bracket-wrapper {
         overflow: hidden;
       }
+      .tree:not(.interactive) .inside-bracket-wrapper {
+        animation-duration: 0s !important;
+      }
       .tr:not(.collapsed) + .inside-bracket-wrapper {
         animation: linear 0.2s expand-height;
       }
@@ -96,7 +113,7 @@ export default class SchemaTree extends LitElement {
   /* eslint-disable indent */
   render() {
     return html`
-      <div class="tree">
+      <div class="tree ${this.interactive ? 'interactive' : ''}">
         <div class="toolbar">
           ${this.data && this.data['::description'] ? html`<span class='m-markdown' style="margin-block-start: 0"> ${unsafeHTML(marked(this.data['::description'] || ''))}</span>` : html`<div>&nbsp;</div>`}
           <div class="toolbar-item" @click='${() => this.toggleSchemaDescription()}'> 


### PR DESCRIPTION
This PR allows the "collapse" animations in schema viewer (tree/table) to be played only when the user interacts with the tree.

This fixes some glitch the first time the schema is shown or when the schema tab is clicked.
