### PR TITLE
Adding highlighting to XML examples

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -603,14 +603,14 @@ export default class ApiRequest extends LitElement {
             </div>`
           : html`
             <div class="tab-content col m-markdown" style="flex:1; display:${this.activeResponseTab === 'response' ? 'flex' : 'none'};" >
-              <syntax-highlighter style="min-height: 60px" mime-type="${this.responseContentType}" .content="${this.responseText}" copy/>
+              <syntax-highlighter style="min-height: 60px" mime-type="${this.responseContentType}" .content="${this.responseText}"/>
             </div>`
         }
         <div class="tab-content col m-markdown" style="flex:1;display:${this.activeResponseTab === 'headers' ? 'flex' : 'none'};" >
-          <syntax-highlighter language="http" .content="${this.responseHeaders}" copy/>
+          <syntax-highlighter language="http" .content="${this.responseHeaders}"/>
         </div>
         <div class="tab-content m-markdown col" style="flex:1;display:${this.activeResponseTab === 'curl' ? 'flex' : 'none'};">
-          <syntax-highlighter class="fs-exclude" data-hj-suppress data-sl="mask" language="shell" .content="${curlSyntax.trim()}" copy/>
+          <syntax-highlighter class="fs-exclude" data-hj-suppress data-sl="mask" language="shell" .content="${curlSyntax.trim()}"/>
         </div>
       </div>`;
   }

--- a/src/components/api-response.js
+++ b/src/components/api-response.js
@@ -273,7 +273,7 @@ export default class ApiResponse extends LitElement {
         ? html`
           ${mimeRespDetails.examples[0].exampleSummary && mimeRespDetails.examples[0].exampleSummary.length > 80 ? html`<div style="padding: 4px 0"> ${mimeRespDetails.examples[0].exampleSummary} </div>` : ''}
           ${mimeRespDetails.examples[0].exampleDescription ? html`<div class="m-markdown-small" style="padding: 4px 0"> ${unsafeHTML(marked(mimeRespDetails.examples[0].exampleDescription || ''))} </div>` : ''}
-          <syntax-highlighter class='example-panel generic-tree border-top pad-top-8' mime-type="${mimeRespDetails.examples[0].exampleType}" .content="${mimeRespDetails.examples[0].exampleValue}" copy/>`
+          <syntax-highlighter class='example-panel generic-tree border-top pad-top-8' mime-type="${mimeRespDetails.examples[0].exampleType}" .content="${mimeRespDetails.examples[0].exampleValue}"/>`
         : html`
           <span class = 'example-panel generic-tree ${this.renderStyle === 'read' ? 'border pad-8-16' : 'border-top pad-top-8'}'>
             <select aria-label='response body example' @change='${(e) => this.onSelectExample(e)}'>
@@ -285,21 +285,13 @@ export default class ApiResponse extends LitElement {
               <div class="example" data-example = '${v.exampleId}' style = "display: ${v.exampleId === mimeRespDetails.selectedExample ? 'block' : 'none'}">
                 ${v.exampleSummary && v.exampleSummary.length > 80 ? html`<div style="padding: 4px 0"> ${v.exampleSummary} </div>` : ''}
                 ${v.exampleDescription && v.exampleDescription !== v.exampleSummary ? html`<div class="m-markdown-small" style="padding: 4px 0"> ${unsafeHTML(marked(v.exampleDescription || ''))} </div>` : ''}
-                <syntax-highlighter mime-type="${v.exampleType}" .content="${v.exampleValue}" copy/>
+                <syntax-highlighter mime-type="${v.exampleType}" .content="${v.exampleValue}"/>
               </div>  
             `)}
           </span>  
         `
       }
     `;
-  }
-
-  renderExampleTemplate(example) {
-    return html`<syntax-highlighter content-type="${example.exampleType}" content="${example.exampleValue}"/>`;
-  }
-
-  exampleValueTemplate(example) {
-    return html`<syntax-highlighter content-type="${example.exampleType}" content="${example.exampleValue}" copy/>`;
   }
 
   mimeSchemaTemplate(mimeRespDetails) {

--- a/src/components/api-response.js
+++ b/src/components/api-response.js
@@ -10,8 +10,10 @@ import InputStyles from '../styles/input-styles';
 import TabStyles from '../styles/tab-styles';
 import BorderStyles from '../styles/border-styles';
 import SchemaStyles from '../styles/schema-styles';
+import PrismStyles from '../styles/prism-styles';
 import './schema-tree';
 import './schema-table';
+import './syntax-highlighter';
 
 export default class ApiResponse extends LitElement {
   constructor() {
@@ -47,6 +49,7 @@ export default class ApiResponse extends LitElement {
       TableStyles,
       InputStyles,
       BorderStyles,
+      PrismStyles,
       css`
       .resp-head{
         vertical-align: middle;
@@ -189,7 +192,7 @@ export default class ApiResponse extends LitElement {
           </div>
           ${Object.keys(this.mimeResponsesForEachStatus[status]).length === 0
             ? ''
-            : html`  
+            : html`
               <div class="tab-panel col">
                 <div class="tab-buttons row" @click="${(e) => { if (e.target.tagName.toLowerCase() === 'button') { this.activeSchemaTab = e.target.dataset.tab; } }}" >
                   <button class="tab-btn ${this.activeSchemaTab === 'model' ? 'active' : ''}" data-tab='model'>${getI18nText('operations.model')}</button>
@@ -270,17 +273,7 @@ export default class ApiResponse extends LitElement {
         ? html`
           ${mimeRespDetails.examples[0].exampleSummary && mimeRespDetails.examples[0].exampleSummary.length > 80 ? html`<div style="padding: 4px 0"> ${mimeRespDetails.examples[0].exampleSummary} </div>` : ''}
           ${mimeRespDetails.examples[0].exampleDescription ? html`<div class="m-markdown-small" style="padding: 4px 0"> ${unsafeHTML(marked(mimeRespDetails.examples[0].exampleDescription || ''))} </div>` : ''}
-          ${mimeRespDetails.examples[0].exampleFormat === 'json'
-            ? html`
-              <json-tree 
-                render-style = '${this.renderStyle}'
-                .data="${mimeRespDetails.examples[0].exampleValue}"
-                class = 'example-panel pad-top-8'
-              ></json-tree>`
-            : html`
-              <pre class = 'example-panel generic-tree border-top pad-top-8'>${mimeRespDetails.examples[0].exampleValue}</pre>
-            `
-          }`
+          <syntax-highlighter class='example-panel generic-tree border-top pad-top-8' mime-type="${mimeRespDetails.examples[0].exampleType}" .content="${mimeRespDetails.examples[0].exampleValue}" copy/>`
         : html`
           <span class = 'example-panel generic-tree ${this.renderStyle === 'read' ? 'border pad-8-16' : 'border-top pad-top-8'}'>
             <select aria-label='response body example' @change='${(e) => this.onSelectExample(e)}'>
@@ -292,20 +285,21 @@ export default class ApiResponse extends LitElement {
               <div class="example" data-example = '${v.exampleId}' style = "display: ${v.exampleId === mimeRespDetails.selectedExample ? 'block' : 'none'}">
                 ${v.exampleSummary && v.exampleSummary.length > 80 ? html`<div style="padding: 4px 0"> ${v.exampleSummary} </div>` : ''}
                 ${v.exampleDescription && v.exampleDescription !== v.exampleSummary ? html`<div class="m-markdown-small" style="padding: 4px 0"> ${unsafeHTML(marked(v.exampleDescription || ''))} </div>` : ''}
-                ${v.exampleFormat === 'json'
-                  ? html`
-                    <json-tree 
-                      render-style = '${this.renderStyle}'
-                      .data = '${v.exampleValue}'
-                    ></json-tree>`
-                  : html`<pre class="generic-tree">${v.exampleValue}</pre>`
-                }
+                <syntax-highlighter mime-type="${v.exampleType}" .content="${v.exampleValue}" copy/>
               </div>  
             `)}
           </span>  
         `
       }
     `;
+  }
+
+  renderExampleTemplate(example) {
+    return html`<syntax-highlighter content-type="${example.exampleType}" content="${example.exampleValue}"/>`;
+  }
+
+  exampleValueTemplate(example) {
+    return html`<syntax-highlighter content-type="${example.exampleType}" content="${example.exampleValue}" copy/>`;
   }
 
   mimeSchemaTemplate(mimeRespDetails) {

--- a/src/components/json-tree.js
+++ b/src/components/json-tree.js
@@ -1,6 +1,4 @@
 import { LitElement, html, css } from 'lit';
-import { copyToClipboard } from '../utils/common-utils';
-import { getI18nText } from '../languages';
 import FontStyles from '../styles/font-styles.js';
 import BorderStyles from '../styles/border-styles';
 import InputStyles from '../styles/input-styles';
@@ -109,7 +107,6 @@ export default class JsonTree extends LitElement {
       }
       .toolbar-item {
         cursor: pointer;
-        margin: 0 1rem !important;
         flex-shrink: 0;
       }
       .tree .toolbar .toolbar-item {
@@ -152,12 +149,6 @@ export default class JsonTree extends LitElement {
   render() {
     return html`
       <div class="json-tree tree ${this.interactive ? 'interactive' : ''}">
-        <div class="toolbar"> 
-          <div>&nbsp;</div>
-          <div class="toolbar-item">
-            <button class="m-btn outline-primary" part="btn btn-fill" @click='${(e) => { copyToClipboard(JSON.stringify(this.data, null, 2), e); }}'>${getI18nText('operations.copy')}</button>
-          </div>
-        </div>
         ${this.generateTree(this.data, true)}
       </div>  
     `;

--- a/src/components/syntax-highlighter.js
+++ b/src/components/syntax-highlighter.js
@@ -1,0 +1,164 @@
+import { LitElement, html, css } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { marked } from 'marked';
+
+import Prism from 'prismjs';
+import './json-tree';
+
+// It's possible none of these imports are actually necessary and should just be removed
+import 'prismjs/components/prism-css';
+import 'prismjs/components/prism-yaml';
+import 'prismjs/components/prism-go';
+import 'prismjs/components/prism-ruby';
+import 'prismjs/components/prism-java';
+import 'prismjs/components/prism-json';
+import 'prismjs/components/prism-bash';
+import 'prismjs/components/prism-python';
+import 'prismjs/components/prism-http';
+import 'prismjs/components/prism-csharp';
+
+import PrismStyles from '../styles/prism-styles';
+import FontStyle from '../styles/font-styles';
+import InputStyle from '../styles/input-styles';
+import { getI18nText } from '../languages';
+import { copyToClipboard } from '../utils/common-utils';
+
+/**
+ * Mapping mime-type => prism language
+ */
+const LANGUAGES = [
+  {
+    pattern: /json/,
+    language: 'json'
+  }, {
+    pattern: /xml/,
+    language: 'html'
+  }
+];
+
+/**
+ * Syntax Highlighter component.
+ */
+class SyntaxHighlighter extends LitElement {
+  static get properties() {
+    return {
+      content: { type: Object },
+      language: { type: String, attribute: 'language' },
+      mimeType: { type: String, attribute: 'mime-type' },
+      copy: { type: Boolean, attribute: 'copy' }
+    };
+  }
+
+  static finalizeStyles() {
+    return [PrismStyles, FontStyle, InputStyle, css`
+        :host {
+            font-weight: normal;
+        }
+
+        div {
+            position: relative;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .toolbar-copy-btn {
+            position: absolute;
+            top: 0px;
+            right: 0px;
+            margin-right: 8px;
+          }
+          .toolbar-copy-btn + pre {
+            white-space: pre;
+            max-height:400px;
+            overflow: auto;
+            display: flex;
+            padding-right: 70px;
+          }
+    `];
+  }
+
+  /**
+   * Returns the prism language to use based on language/content type
+   * @returns {string} The language to use
+   */
+  detectLanguage() {
+    if (this.language) {
+      return this.language?.toLowerCase();
+    }
+
+    if (this.mimeType) {
+      const lcMimeType = this.mimeType?.toLowerCase();
+      return LANGUAGES.find(def => def.pattern.test(lcMimeType))?.language;
+    }
+
+    return null;
+  }
+
+  render() {
+    return this.renderCopyWrapper(this.renderHighlight());
+  }
+
+  /**
+   * Render the highlighted content.
+   * @returns Highlighter
+   */
+  renderHighlight() {
+    const lang = this.detectLanguage();
+    const grammar = Prism.languages[lang];
+    
+    if (lang === 'json' && typeof this.content !== 'string') {
+      return html`<json-tree .data="${this.content}"/>`;
+    }
+
+    return grammar
+      ? html`<pre><code>${unsafeHTML(Prism.highlight(this.content?.toString(), grammar, lang))}</code></pre>`
+      : html`<pre>${this.content?.toString()}</pre>`;
+  }
+
+  /**
+   * Render a copy-to-clipboard button.
+   * @param {*} content Content
+   * @returns Content
+   */
+  renderCopyWrapper(content) {
+    if (this.copy) {
+      return html`<div>
+                <button 
+                    class="m-btn outline-primary toolbar-copy-btn" 
+                    @click='${this.copyToClipboard}' 
+                    part="btn btn-fill btn-copy">${getI18nText('operations.copy')}</button>
+                    ${content}
+            </div>`;
+    }
+
+    return content;
+  }
+
+  /**
+   * Copy to clipboard.
+   * @param {Event} e Event
+   */
+  copyToClipboard(e) {
+    const data = this.detectLanguage() === 'json' && typeof this.content !== 'string'
+      ? JSON.stringify(this.content, null, 2)
+      : this.content?.toString();
+
+    copyToClipboard(data, e);
+  }
+}
+
+/*
+ * Configure marked globally.
+ */
+marked.setOptions({
+  highlight(code, lang) {
+    if (Prism.languages[lang]) {
+      return Prism.highlight(code, Prism.languages[lang], lang);
+    }
+    return code;
+  },
+});
+
+if (!customElements.get('openapi-explorer')) {
+  customElements.define('syntax-highlighter', SyntaxHighlighter);
+}

--- a/src/components/syntax-highlighter.js
+++ b/src/components/syntax-highlighter.js
@@ -45,7 +45,6 @@ class SyntaxHighlighter extends LitElement {
       content: { type: Object },
       language: { type: String, attribute: 'language' },
       mimeType: { type: String, attribute: 'mime-type' },
-      copy: { type: Boolean, attribute: 'copy' }
     };
   }
 
@@ -121,17 +120,13 @@ class SyntaxHighlighter extends LitElement {
    * @returns Content
    */
   renderCopyWrapper(content) {
-    if (this.copy) {
-      return html`<div>
+    return html`<div>
                 <button 
                     class="m-btn outline-primary toolbar-copy-btn" 
                     @click='${this.copyToClipboard}' 
                     part="btn btn-fill btn-copy">${getI18nText('operations.copy')}</button>
                     ${content}
             </div>`;
-    }
-
-    return content;
   }
 
   /**

--- a/src/openapi-explorer.js
+++ b/src/openapi-explorer.js
@@ -1,20 +1,5 @@
 import { LitElement, css } from 'lit';
 
-import { marked } from 'marked';
-import Prism from 'prismjs';
-
-// It's possible none of these imports are actually necessary and should just be removed
-import 'prismjs/components/prism-css';
-import 'prismjs/components/prism-yaml';
-import 'prismjs/components/prism-go';
-import 'prismjs/components/prism-ruby';
-import 'prismjs/components/prism-java';
-import 'prismjs/components/prism-json';
-import 'prismjs/components/prism-bash';
-import 'prismjs/components/prism-python';
-import 'prismjs/components/prism-http';
-import 'prismjs/components/prism-csharp';
-
 // Styles
 import FontStyles from './styles/font-styles.js';
 import InputStyles from './styles/input-styles';
@@ -36,7 +21,7 @@ import ProcessSpec from './utils/spec-parser';
 import mainBodyTemplate from './templates/mainBodyTemplate';
 import apiRequestStyles from './styles/api-request-styles';
 import { checkForAuthToken } from './templates/security-scheme-template';
-
+import './components/syntax-highlighter';
 export default class OpenApiExplorer extends LitElement {
   constructor() {
     super();
@@ -412,15 +397,6 @@ export default class OpenApiExplorer extends LitElement {
     if (!this.fetchCredentials || !'omit, same-origin, include,'.includes(`${this.fetchCredentials},`)) { this.fetchCredentials = ''; }
 
     if (!this.showAdvancedSearchDialog) { this.showAdvancedSearchDialog = false; }
-
-    marked.setOptions({
-      highlight(code, lang) {
-        if (Prism.languages[lang]) {
-          return Prism.highlight(code, Prism.languages[lang], lang);
-        }
-        return code;
-      },
-    });
 
     window.addEventListener('hashchange', () => {
       this.scrollTo(getCurrentElement());

--- a/src/styles/font-styles.js
+++ b/src/styles/font-styles.js
@@ -72,10 +72,15 @@ export default css`
   }
   
   code,
-  pre {
+  pre,
+  syntax-highlighter {
     margin: 0px;
     font-family: var(--font-mono);
     font-size: calc(var(--font-size-mono) - 1px);
+  }
+
+  .m-markdown syntax-highlighter {
+    display: block;
   }
 
   .m-markdown,
@@ -125,7 +130,8 @@ export default css`
   }
 
   .m-markdown-small code,
-  .m-markdown code {
+  .m-markdown code,
+  .m-markdown syntax-highlighter {
     padding: 1px 6px;
     border-radius: 2px;
     color: var(--inline-code-fg);
@@ -134,12 +140,12 @@ export default css`
     line-height: 1.2;
   }
 
-  .m-markdown-small code {
+  .m-markdown-small code, .m-markdown-small syntax-highlighter {
     font-size: calc(var(--font-size-mono) - 1px);
   }
 
   .m-markdown-small pre,
-  .m-markdown pre {
+  .m-markdown pre, .m-markdown syntax-highlighter {
     white-space: pre-wrap;
     overflow-x: auto;
     line-height: normal;
@@ -147,13 +153,13 @@ export default css`
     border: 1px solid var(--code-border-color);
   }
 
-  .m-markdown pre {
+  .m-markdown pre, .m-markdown syntax-highlighter {
     padding: 8px;
     background-color: var(--bg2);
     color:var(--code-fg);
   }
 
-  .m-markdown-small pre {
+  .m-markdown-small pre, .m-markdown-small syntax-highlighter {
     margin-top: 4px;
     padding: 2px 4px;
     background-color: var(--bg3);
@@ -172,7 +178,8 @@ export default css`
     background-color: transparent;
   }
 
-  .m-markdown-small pre code {
+  .m-markdown-small pre code,
+  .m-markdown-small syntax-highlighter {
     color: var(--fg2);
     background-color: var(--bg3);
   }

--- a/src/styles/input-styles.js
+++ b/src/styles/input-styles.js
@@ -53,21 +53,7 @@ export default css`
   opacity: 0.4;
 }
 
-.toolbar-copy-btn {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  margin-right: 8px;
-}
-.toolbar-copy-btn + pre {
-  white-space: pre;
-  max-height:400px;
-  overflow: auto;
-  display: flex;
-  padding-right: 70px;
-}
-
-input, textarea, select, button, pre {
+input, textarea, select, button {
   color:var(--fg);
   outline: none;
   background-color: var(--input-bg);
@@ -79,7 +65,6 @@ button {
 }
 
 /* Form Inputs */
-pre,
 select,
 textarea,
 input[type="file"],

--- a/src/styles/prism-styles.js
+++ b/src/styles/prism-styles.js
@@ -59,6 +59,7 @@ pre[class*="language-"] {
 }
 
 .token.property,
+.token.tag,
 .token.class-name,
 .token.constant,
 .token.symbol {
@@ -68,6 +69,7 @@ pre[class*="language-"] {
 .token.selector,
 .token.important,
 .token.atrule,
+.token.attr-name,
 .token.keyword,
 .token.builtin {
   color: var(--code-keyword-color);
@@ -107,5 +109,11 @@ pre[class*="language-"] {
 
 .token.inserted {
   color: green;
+}
+
+.token.header {
+  /* conflict with .header */
+  color: unset;
+  background: unset;
 }
 `;

--- a/src/templates/code-samples-template.js
+++ b/src/templates/code-samples-template.js
@@ -29,9 +29,7 @@ export default function codeSamplesTemplate(xCodeSamples) {
       const fullSource = sanitizedSource.join('\n');
       return html`
         <div class="tab-content m-markdown code-sample-wrapper" style= "display:${i === 0 ? 'block' : 'none'}" data-tab = '${v.lang}${i}'>
-          <button class="m-btn outline-primary toolbar-copy-btn" @click='${(e) => { copyToClipboard(v.source, e); }}'>${getI18nText('operations.copy')}</button>
-          <pre><code>${Prism.languages[v.lang?.toLowerCase()] ? unsafeHTML(Prism.highlight(fullSource, Prism.languages[v.lang?.toLowerCase()], v.lang?.toLowerCase())) : fullSource}
-          </code></pre>
+          <syntax-highlighter language="${v.lang}" .content="${fullSource}" copy/>
         </div>`;
     })
     }

--- a/src/templates/code-samples-template.js
+++ b/src/templates/code-samples-template.js
@@ -1,8 +1,4 @@
 import { html } from 'lit';
-import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import Prism from 'prismjs';
-import { copyToClipboard } from '../utils/common-utils';
-import { getI18nText } from '../languages';
 
 /* eslint-disable indent */
 export default function codeSamplesTemplate(xCodeSamples) {
@@ -29,7 +25,7 @@ export default function codeSamplesTemplate(xCodeSamples) {
       const fullSource = sanitizedSource.join('\n');
       return html`
         <div class="tab-content m-markdown code-sample-wrapper" style= "display:${i === 0 ? 'block' : 'none'}" data-tab = '${v.lang}${i}'>
-          <syntax-highlighter language="${v.lang}" .content="${fullSource}" copy/>
+          <syntax-highlighter language="${v.lang}" .content="${fullSource}"/>
         </div>`;
     })
     }

--- a/src/templates/components-template.js
+++ b/src/templates/components-template.js
@@ -3,7 +3,6 @@ import { schemaInObjectNotation } from '../utils/schema-utils';
 import { html } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { marked } from 'marked';
-import '../components/json-tree';
 import '../components/schema-tree';
 
 function componentBodyTemplate(sComponent) {

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -152,7 +152,9 @@ export default function setTheme(theme = {}) {
     /*Code Syntax Color*/
     --code-fg:${newTheme.codeFg};
     --inline-code-fg:${newTheme.inlineCodeFg};
-    
+    --code-property-color:${newTheme.codePropertyColor};
+    --code-keyword-color:${newTheme.codeKeywordColor};
+    --code-operator-color:${newTheme.codeOperatorColor};
 
     /* Computed Color properties */
     --primary-color: ${theme.primaryColor};


### PR DESCRIPTION
This PR add highlighting to xml examples in response:

![highlight_xml](https://github.com/Rhosys/openapi-explorer/assets/2384547/3d4e3872-4d30-4e1a-a91f-441133209592)

Moreover, some css properties used by prism were not defined from the theme to the css variable. I have fixed that too.